### PR TITLE
Fix Docker tag in make release target

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -24,6 +24,8 @@ jobs:
     - run: make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   slack-on-fail:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ NEXTTAG := $(shell { git tag --list --merged HEAD --sort=-v:refname; echo v0.0.0
 DOCKER_LOGIN = printenv DOCKER_PASSWORD | docker login --username "$(DOCKER_USERNAME)" --password-stdin
 
 release: REGISTRY = cashapp
+release: VERSION = $(NEXTTAG)
 release:
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)


### PR DESCRIPTION
Add missing GitHub Actions environment variables for access to Dockerhub.

Fix Docker tag in make release target so that it is `NEXTTAG` rather than 
`git describe --tags --dirty  --always`, which lags one version behind.