### PR TITLE
Add leader-election to operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ your host machine (e.g. Mac laptop), outside the cluster
 
     make cluster-create                        # Create lightweight local cluster
     kubectl apply -f deployment/guppyecho.yaml # Add sample gRPC deployment
+    kubectl create namespace transflect        # namespace used for leader-election
     make run-local-operator                    # Start transflect on host machine
 
 Use <kbd>Ctrl</kbd> + <kbd>\\</kbd> to instantly shutdown the local operator

--- a/cluster-test.sh
+++ b/cluster-test.sh
@@ -28,6 +28,7 @@ main() {
     attempts=25
 
     # Set up initial deployments and transflect
+    # kubectl create namespace transflect # make run-local-operator needs transflect namespace for lease lock
     kubectl apply -f deployment/transflect.yaml
     kubectl apply -f deployment/routeguide.yaml
     kubectl apply -f deployment/guppyecho.yaml

--- a/cmd/transflect-operator/main.go
+++ b/cmd/transflect-operator/main.go
@@ -22,11 +22,12 @@ var (
 )
 
 type config struct {
-	UseIngress bool             `short:"i" help:"Create and use temporary ingress to access temporary service, e.g. from outside cluster"`
-	Address    string           `short:"a" help:"gRPC reflection server address, host:port"`
-	Plaintext  bool             `short:"p" help:"Use plain-text; no TLS"`
-	LogFormat  string           `help:"Log format ('json', 'std')" enum:"json,std" default:"std"`
-	Version    kong.VersionFlag `short:"v" help:"Print version information"`
+	UseIngress     bool             `short:"i" help:"Create and use temporary ingress to access temporary service, e.g. from outside cluster"`
+	Address        string           `short:"a" help:"gRPC reflection server address, host:port"`
+	Plaintext      bool             `short:"p" help:"Use plain-text; no TLS"`
+	LeaseNamespace string           `help:"Namespace in which leader election lease is created" default:"transflect"`
+	LogFormat      string           `help:"Log format ('json', 'std')" enum:"json,std" default:"std"`
+	Version        kong.VersionFlag `short:"v" help:"Print version information"`
 }
 
 func main() {

--- a/deployment/transflect.yaml
+++ b/deployment/transflect.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: transflect
 spec:
+  replicas: 3
   selector:
     matchLabels:
       app: transflect
@@ -54,6 +55,9 @@ rules:
   - apiGroups: [ networking.istio.io ]
     resources: [ envoyfilters ]
     verbs: [ create, delete, get, list, update ]
+  - apiGroups: [ coordination.k8s.io ]
+    resources: [ leases ]
+    verbs: [ create, get, update ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/alecthomas/kong v0.2.16
 	github.com/gogo/protobuf v1.3.2
+	github.com/google/uuid v1.1.2
 	github.com/jpillora/backoff v1.0.0
 	github.com/juliaogris/guppy v0.0.6
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -530,6 +531,7 @@ k8s.io/klog/v2 v2.8.0 h1:Q3gmuM9hKEjefWFFYF0Mat+YyFJvsUyYuwyNNJ5C9Ts=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
+k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=


### PR DESCRIPTION
Add leader-election to operator so that several operators may be ready
in a cluster, but only one at a time executes.

This change borrows heavily for the Kubernetes client-go
[leader-election example](https://github.com/kubernetes/client-go/blob/a31b18a6ac98bbff0dd1055707dfde1b0a98ff68/examples/leader-election/main.go).

Issue: #8 