### PR TITLE
Add leader-election to operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ GEN_ISTIO_CONFIG = $(O)/transflect \
                         --app echo \
                         --namespace echo \
                         localhost:9090 $(ISTIO_OUT)
-LOCAL_OPERATOR_CMD = $(O)/transflect-operator --plaintext --use-ingress --address localhost:80
+LOCAL_OPERATOR_CMD = $(O)/transflect-operator --plaintext --use-ingress --lease-namespace default --address localhost:80
 
 istio: istio-config istio-apply
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ your host machine (e.g. Mac laptop), outside the cluster
 
     make cluster-create                        # Create lightweight local cluster
     kubectl apply -f deployment/guppyecho.yaml # Add sample gRPC deployment
+    kubectl create namespace transflect        # namespace used for leader-election
     make run-local-operator                    # Start transflect on host machine
 
 Use <kbd>Ctrl</kbd> + <kbd>\\</kbd> to instantly shutdown the local operator

--- a/cmd/transflect-operator/operator.go
+++ b/cmd/transflect-operator/operator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cashapp/transflect/pkg/transflect"
+	"github.com/google/uuid"
 	"github.com/jpillora/backoff"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -24,6 +25,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -35,6 +38,7 @@ type operator struct {
 	deployInformer informerv1.DeploymentInformer
 	queue          workqueue.RateLimitingInterface
 	stopper        chan struct{}
+	stopLock       sync.Mutex
 	wg             sync.WaitGroup
 	// activeState records the deployment revision and its grpc port
 	// for which an EnvoyFilter has been created. The port is required
@@ -47,10 +51,11 @@ type operator struct {
 	// so that no two updates for a single deployment can run concurrently.
 	deploymentLocker transflect.MutexMap
 
-	useIngress bool
-	plaintext  bool
-	address    string
-	version    string
+	useIngress     bool
+	plaintext      bool
+	address        string
+	version        string
+	leaseNamespace string
 }
 
 type activeEntry struct {
@@ -68,26 +73,57 @@ func newOperator(cfg *config) (*operator, error) {
 		k8s:   k8s,
 		istio: istio,
 
-		useIngress: cfg.UseIngress,
-		plaintext:  cfg.Plaintext,
-		address:    cfg.Address,
-		version:    "transflect-" + version,
+		useIngress:     cfg.UseIngress,
+		plaintext:      cfg.Plaintext,
+		address:        cfg.Address,
+		version:        "transflect-" + version,
+		leaseNamespace: cfg.LeaseNamespace,
 	}
 	return op, nil
 }
 
-func (o *operator) start() error {
+// start is concerned with setting up leader-election. If the current
+// process is chosen as leader, the main operator work is kicked off in
+// startLeading.
+func (o *operator) start(ctx context.Context) error {
+	// Run leader election
+	var err error
+	id := uuid.New().String()
+	ctx, cancel := context.WithCancel(ctx)
+	callbacks := leaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			log.Debug().Str("leaderID", id).Msg("Starting to lead")
+			if err = o.startLeading(); err != nil { // kick off operator
+				// stop the operator before we release the lease lock
+				// with `cancel()` so two operators are not running at
+				// the same time.
+				o.stop()
+				cancel()
+			}
+		},
+		OnStoppedLeading: func() {
+			log.Debug().Str("leaderID", id).Msg("Stop leading")
+			o.stop()
+		},
+		OnNewLeader: func(newID string) {
+			log.Debug().Str("leaderID", id).Str("newLeaderID", newID).Msg("New leader elected")
+		},
+	}
+	lock := o.newLock(id)
+	leaderelection.RunOrDie(ctx, newElection(lock, callbacks))
+	return err
+}
+
+func (o *operator) startLeading() error {
+	o.stopper = make(chan struct{})
+
 	// Initialise activeState for existing transflect EnvoyFilters
 	// to determine if EnvoyFilter upsert should be processed.
 	if err := o.syncActive(); err != nil {
 		return fmt.Errorf("cannot start operator: %w", err)
 	}
 
-	// Initialise work-queue and stopper channel
-	o.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	o.stopper = make(chan struct{})
-
-	// Initialise informers
+	// Initialise informers and queue
 	informerFactory := informers.NewSharedInformerFactory(o.k8s, time.Second*30)
 	o.rsInformer = informerFactory.Apps().V1().ReplicaSets()
 	if err := o.rsInformer.Informer().SetWatchErrorHandler(watchErrorHandler); err != nil {
@@ -104,6 +140,7 @@ func (o *operator) start() error {
 	o.deployInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: o.cleanupDeployment,
 	})
+	o.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	log.Debug().Msg("Start leading: informer event handlers registered")
 
 	// Run workers and informers
@@ -160,6 +197,14 @@ func (o *operator) runWorker() {
 }
 
 func (o *operator) stop() {
+	o.stopLock.Lock()
+	defer o.stopLock.Unlock()
+	select {
+	case <-o.stopper:
+		return // stopper is already closed
+	default:
+	}
+
 	close(o.stopper)
 	o.wg.Wait()
 	log.Debug().Msg("All workers have finished")
@@ -344,6 +389,30 @@ func getConfig() (*rest.Config, error) {
 		return nil, errors.Wrap(err, "cannot find kube config")
 	}
 	return kubeCfg, nil
+}
+
+func (o *operator) newLock(id string) *resourcelock.LeaseLock {
+	return &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      "transflect-leader",
+			Namespace: o.leaseNamespace,
+		},
+		Client: o.k8s.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+}
+
+func newElection(lock *resourcelock.LeaseLock, callbacks leaderelection.LeaderCallbacks) leaderelection.LeaderElectionConfig {
+	return leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   20 * time.Second,
+		RenewDeadline:   15 * time.Second,
+		RetryPeriod:     5 * time.Second,
+		Callbacks:       callbacks,
+	}
 }
 
 func watchErrorHandler(_ *cache.Reflector, err error) {

--- a/cmd/transflect-operator/probes.go
+++ b/cmd/transflect-operator/probes.go
@@ -28,14 +28,16 @@ func newProbesServer() *probesServer {
 	}
 }
 
-func (s *probesServer) start() error {
+func (s *probesServer) start(ctx context.Context) error {
+	go s.stopOnCancel(ctx)
 	if err := s.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		return errors.Wrap(err, "cannot start probes server")
 	}
 	return nil
 }
 
-func (s *probesServer) stop() {
+func (s *probesServer) stopOnCancel(ctx context.Context) {
+	<-ctx.Done()
 	if err := s.Shutdown(context.Background()); err != nil {
 		log.Logger.Error().Err(err).Msg("cannot stop HTTP server")
 	}

--- a/deployment/transflect.yaml
+++ b/deployment/transflect.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: transflect
 spec:
+  replicas: 3
   selector:
     matchLabels:
       app: transflect
@@ -36,6 +37,9 @@ spec:
           # image: cashapp/transflect # Use image from Dockerhub
           image: k3d-registry.transflect.local:420/transflect:latest
           imagePullPolicy: Always
+          env:
+          - name: LEASE_NAMESPACE
+            valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -54,6 +58,9 @@ rules:
   - apiGroups: [ networking.istio.io ]
     resources: [ envoyfilters ]
     verbs: [ create, delete, get, list, update ]
+  - apiGroups: [ coordination.k8s.io ]
+    resources: [ leases ]
+    verbs: [ create, get, update ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/alecthomas/kong v0.2.16
 	github.com/gogo/protobuf v1.3.2
+	github.com/google/uuid v1.1.2
 	github.com/jpillora/backoff v1.0.0
 	github.com/juliaogris/guppy v0.0.6
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -530,6 +531,7 @@ k8s.io/klog/v2 v2.8.0 h1:Q3gmuM9hKEjefWFFYF0Mat+YyFJvsUyYuwyNNJ5C9Ts=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
+k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=


### PR DESCRIPTION
Add leader-election to operator so that several operators may be ready
in a cluster, but only one at a time executes.

Add cleanup on cancelled context to probes server and signal handler, to
ensure quick leaser release and handover.

This change leans heavily on k8s client-go leader-election example.
https://github.com/kubernetes/client-go/blob/a31b18a6ac98bbff0dd1055707dfde1b0a98ff68/examples/leader-election/main.go

There are no tests for the leader election, but I have manually tested it.

This PR is a re-creation of #7 which got deleted as it was a stacked PR with #6 and not rebased before merge/delete of base branch.

issue: #8 