### PR TITLE
Add workqueue metrics

### DIFF
--- a/cluster-test.sh
+++ b/cluster-test.sh
@@ -73,6 +73,23 @@ check_metrics() {
 transflect_operations_total{status="success",type="delete"} 1
 transflect_operations_total{status="success",type="upsert"} 3
 transflect_preprocess_error_total 0'
+    if [ "${metrics_want}" != "${metrics_got}" ]; then
+        printf "unexpected metrics value\n want:\n%s\n\n got:\n%s\n" "${metrics_want}" "${metrics_got}"
+        exit 1
+    fi
+
+    metrics_got=$(curl -s localhost:9090/metrics | awk -F'{' '/^workqueue_/ {print $1}' | sort -u)
+    metrics_want='workqueue_adds_total
+workqueue_depth
+workqueue_latency_seconds_bucket
+workqueue_latency_seconds_count
+workqueue_latency_seconds_sum
+workqueue_longest_running_processor_seconds
+workqueue_retries_total
+workqueue_unfinished_work_seconds
+workqueue_work_duration_seconds_bucket
+workqueue_work_duration_seconds_count
+workqueue_work_duration_seconds_sum'
 
     if [ "${metrics_want}" != "${metrics_got}" ]; then
         printf "unexpected metrics value\n want:\n%s\n\n got:\n%s\n" "${metrics_want}" "${metrics_got}"

--- a/cmd/transflect-operator/main.go
+++ b/cmd/transflect-operator/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/rs/zerolog/pkgerrors"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/util/workqueue"
 )
 
 var (
@@ -46,6 +47,7 @@ func main() {
 
 func run(cfg *config) error {
 	setupLogging(cfg)
+	workqueue.SetProvider(&metricsProvider{})
 
 	// create servers
 	probes := newProbesServer(cfg.ProbesPort)

--- a/cmd/transflect-operator/main.go
+++ b/cmd/transflect-operator/main.go
@@ -10,8 +10,6 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/cashapp/transflect/pkg/transflect"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/rs/zerolog/pkgerrors"
@@ -21,30 +19,6 @@ import (
 var (
 	version   = "v0.0.0"
 	errSignal = fmt.Errorf("received shutdown signal")
-
-	// metrics
-	// filtersGauge includes filters that already exist at startup.
-	filtersGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "transflect_envoyfilters",
-		Help: "Current number of EnvoyFilters managed by transflect",
-	})
-	processedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "transflect_operations_total",
-		Help: "The total number of transflect operations processed",
-	},
-		[]string{
-			"status", // success, error
-			"type",   // upsert, delete
-		},
-	)
-	preprocessErrCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "transflect_preprocess_error_total",
-		Help: "The total number of replicaset ids popped off the queue that errored before being processed",
-	})
-	ignoredCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "transflect_ignored_total",
-		Help: "The total number of replicaset ids popped off the queue that were ignored and didn't need processing",
-	})
 )
 
 type config struct {

--- a/cmd/transflect-operator/metrics.go
+++ b/cmd/transflect-operator/metrics.go
@@ -3,17 +3,18 @@ package main
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"k8s.io/client-go/util/workqueue"
 )
 
 var (
 	// filtersGauge includes filters that already exist at startup.
 	filtersGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "transflect_envoyfilters",
-		Help: "Current number of EnvoyFilters managed by transflect",
+		Help: "Current number of EnvoyFilters managed by transflect.",
 	})
 	processedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "transflect_operations_total",
-		Help: "The total number of transflect operations processed",
+		Help: "The total number of transflect operations processed.",
 	},
 		[]string{
 			"status", // success, error
@@ -22,10 +23,79 @@ var (
 	)
 	preprocessErrCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "transflect_preprocess_error_total",
-		Help: "The total number of replicaset ids popped off the queue that errored before being processed",
+		Help: "The total number of replicaset ids popped off the queue that errored before being processed.",
 	})
 	ignoredCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "transflect_ignored_total",
-		Help: "The total number of replicaset ids popped off the queue that were ignored and didn't need processing",
+		Help: "The total number of replicaset ids popped off the queue that were ignored and didn't need processing.",
 	})
+
+	// queue metrics.
+	qDepthGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "workqueue_depth",
+		Help: "Current depth of the work queue.",
+	}, []string{"queue_name"})
+
+	qAddsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "workqueue_adds_total",
+		Help: "Total number of items added to the work queue.",
+	}, []string{"queue_name"})
+
+	qLatencyHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "workqueue_latency_seconds",
+		Help: "How long an item stays in the work queue.",
+	}, []string{"queue_name"})
+
+	qWorkDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "workqueue_work_duration_seconds",
+		Help: "How long processing an item from the work queue takes.",
+	}, []string{"queue_name"})
+
+	qUnfinshedWorkGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "workqueue_unfinished_work_seconds",
+		Help: "How long an item has remained unfinished in the work queue.",
+	}, []string{"queue_name"})
+
+	qLongestRunningProcessorGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "workqueue_longest_running_processor_seconds",
+		Help: "Duration of the longest running processor in the work queue.",
+	}, []string{"queue_name"})
+
+	qRetriesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "workqueue_retries_total",
+		Help: "Total number retires as timeout re-adds.",
+	}, []string{"queue_name"})
 )
+
+// metricsProvider implements workqueue.MetricsProvider, also see
+// https://pkg.go.dev/k8s.io/client-go@v0.21.0/util/workqueue#MetricsProvider
+// https://gitlab.com/gitlab-org/build/omnibus-mirror/prometheus/blob/8ac15703b040b18c81307d2a905393f6f29be096/discovery/kubernetes/client_metrics.go
+type metricsProvider struct{}
+
+func (metricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return qDepthGauge.WithLabelValues(name)
+}
+
+func (metricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return qAddsCounter.WithLabelValues(name)
+}
+
+func (metricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return qLatencyHistogram.WithLabelValues(name)
+}
+
+func (metricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return qWorkDurationHistogram.WithLabelValues(name)
+}
+
+func (metricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return qUnfinshedWorkGauge.WithLabelValues(name)
+}
+
+func (metricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return qLongestRunningProcessorGauge.WithLabelValues(name)
+}
+
+func (metricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return qRetriesCounter.WithLabelValues(name)
+}

--- a/cmd/transflect-operator/metrics.go
+++ b/cmd/transflect-operator/metrics.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// filtersGauge includes filters that already exist at startup.
+	filtersGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "transflect_envoyfilters",
+		Help: "Current number of EnvoyFilters managed by transflect",
+	})
+	processedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "transflect_operations_total",
+		Help: "The total number of transflect operations processed",
+	},
+		[]string{
+			"status", // success, error
+			"type",   // upsert, delete
+		},
+	)
+	preprocessErrCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "transflect_preprocess_error_total",
+		Help: "The total number of replicaset ids popped off the queue that errored before being processed",
+	})
+	ignoredCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "transflect_ignored_total",
+		Help: "The total number of replicaset ids popped off the queue that were ignored and didn't need processing",
+	})
+)

--- a/cmd/transflect-operator/operator.go
+++ b/cmd/transflect-operator/operator.go
@@ -145,7 +145,7 @@ func (o *operator) startLeading(ctx context.Context) error {
 	o.deployInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: o.cleanupDeployment,
 	})
-	o.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	o.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "replicasets")
 	log.Debug().Msg("Start leading: informer event handlers registered")
 
 	// Run workers and informers


### PR DESCRIPTION
Add workqueue metrics by implementing workqueue.MetricsProvicer:

- Current depth of the work queue.
- Total number of items added to the work queue.
- How long an item stays in the work queue.
- How long processing an item from the work queue takes.
- How long an item has remained unfinished in the work queue.
- Duration of the longest running processor in the work queue.
- Total number retires as timeout re-adds.